### PR TITLE
Bump to latest iohub

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     numpy
     magicgui
     qtpy
-    iohub
+    iohub>=0.2
 
 python_requires = >=3.10
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,8 @@ install_requires =
     numpy
     magicgui
     qtpy
-    iohub>=0.2
+    iohub==0.2.0a1
+    pydantic_extra_types>=2.9.0
 
 python_requires = >=3.10
 include_package_data = True

--- a/src/napari_iohub/_edit_labels.py
+++ b/src/napari_iohub/_edit_labels.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from napari import Viewer
 import numpy as np
-from iohub.ngff import Plate, Position, Row, Well, open_ome_zarr
+from iohub.ngff.nodes import Plate, Position, Row, Well, open_ome_zarr
 from qtpy.QtWidgets import (
     QFileDialog,
     QFormLayout,

--- a/src/napari_iohub/_reader.py
+++ b/src/napari_iohub/_reader.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Literal
 
 import dask.array as da
 import numpy as np
-from iohub.ngff import (
+from iohub.ngff.nodes import (
     MultiScaleMeta,
     NGFFNode,
     OMEROMeta,

--- a/src/napari_iohub/_reader.py
+++ b/src/napari_iohub/_reader.py
@@ -16,7 +16,7 @@ from iohub.ngff.nodes import (
     _open_store,
     open_ome_zarr,
 )
-from pydantic.color import Color
+from pydantic_extra_types.color import Color
 
 if TYPE_CHECKING:
     from _typeshed import StrOrBytesPath

--- a/src/napari_iohub/_tests/conftest.py
+++ b/src/napari_iohub/_tests/conftest.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from iohub.ngff import open_ome_zarr
+from iohub import open_ome_zarr
 
 
 @pytest.fixture(scope="session")

--- a/src/napari_iohub/_tests/test_reader.py
+++ b/src/napari_iohub/_tests/test_reader.py
@@ -1,6 +1,6 @@
 import os
 
-from iohub.ngff import open_ome_zarr
+from iohub import open_ome_zarr
 from numpy.testing import assert_equal
 
 from napari_iohub import napari_get_reader

--- a/src/napari_iohub/_widget.py
+++ b/src/napari_iohub/_widget.py
@@ -3,7 +3,7 @@ import os
 from typing import Callable
 
 import napari
-from iohub.ngff import Plate, Row, Well, open_ome_zarr
+from iohub.ngff.nodes import Plate, Row, Well, open_ome_zarr
 from napari.qt.threading import create_worker
 from napari.utils.notifications import show_info
 from qtpy.QtCore import Qt


### PR DESCRIPTION
Bumping iohub so that `napari-iohub` can live in the same environment as `iohub`. 

Includes minor import changes to satisfy iohub and pydantic warnings. 

I know that users install from `main`, so feel free to delay this PR. 