### PR TITLE
Fix bug launching plate viewer without ultrack

### DIFF
--- a/src/napari_iohub/__init__.py
+++ b/src/napari_iohub/__init__.py
@@ -3,15 +3,20 @@ import os
 
 from ._edit_labels import EditLabelsWidget
 from ._reader import napari_get_reader
-from ._view_tracks import open_image_and_tracks
 from ._widget import MainWidget
 
 __all__ = (
     "napari_get_reader",
     "MainWidget",
     "EditLabelsWidget",
-    "open_image_and_tracks",
 )
+
+try:
+    from ._view_tracks import open_image_and_tracks
+    __all__ += ("open_image_and_tracks",)
+except ImportError:
+    # napari-iohub[clustering] is not installed
+    pass
 
 _logger = logging.getLogger(__name__)
 _logger.setLevel(os.getenv("NAPARI_IOHUB_LOGGING_LEVEL", logging.DEBUG))

--- a/src/napari_iohub/__init__.py
+++ b/src/napari_iohub/__init__.py
@@ -3,20 +3,15 @@ import os
 
 from ._edit_labels import EditLabelsWidget
 from ._reader import napari_get_reader
+from ._view_tracks import open_image_and_tracks
 from ._widget import MainWidget
 
 __all__ = (
     "napari_get_reader",
     "MainWidget",
     "EditLabelsWidget",
+    "open_image_and_tracks",
 )
-
-try:
-    from ._view_tracks import open_image_and_tracks
-    __all__ += ("open_image_and_tracks",)
-except ImportError:
-    # napari-iohub[clustering] is not installed
-    pass
 
 _logger = logging.getLogger(__name__)
 _logger.setLevel(os.getenv("NAPARI_IOHUB_LOGGING_LEVEL", logging.DEBUG))

--- a/src/napari_iohub/_view_tracks.py
+++ b/src/napari_iohub/_view_tracks.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 from iohub.ngff import open_ome_zarr
 from magicgui import magic_factory
-from ultrack.reader.napari_reader import read_csv
 from xarray import open_zarr
 
 from napari_iohub._reader import fov_to_layers
@@ -84,6 +83,11 @@ def open_image_and_tracks(
         List of layers to add to the viewer.
         (image layers and one labels layer)
     """
+    try:
+        from ultrack.reader.napari_reader import read_csv
+    except ImportError:
+        raise ImportError("Please install napari-iohub[clustering]")
+
     _logger.info(f"Loading images from {images_dataset}")
     image_plate = open_ome_zarr(images_dataset)
     image_fov = image_plate[fov_name]

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{310,311}-{linux,macos,windows}
+envlist = py{310,311,312}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
 python =
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
Fixes #23 

Optional next step: leave out the `Single-cell features` widget from the `napari-iohub` plugin menu if `ultrack` is not installed (I don't actually know how to do that). We still get an error if the user clicks on `Single-cell features` when `ultrack` is not installed. The error is meaningful: `RuntimeError: Failed to import command at 'napari_iohub._view_tracks:open_image_and_tracks': No module named 'ultrack'` so I'm OK if we leave it as is.